### PR TITLE
Rename package for local use without VCS nonsense.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "level-2/transphporm",
+    "name": "clx/transphporm",
     "description": "A new approach at templating",
     "license": "BSD-2-Clause",
     "homepage": "https://github.com/Level-2/Transphporm",


### PR DESCRIPTION
See https://github.com/ClaimLynx/wiki/wiki/Custom-Transphporm.

Composer looks for a package by its canonical name at Packagist/GitHub and whatever VCS is configured in `satis.json` for ClaimLynx.  But it has to match the name in the package's `composer.json` file.  But a fork of a GitHub project, such as our fork of `level-2/transphporm` has to have the same package name as the original.  These are incompatible aims.

This commit will make this ClaimLynx copy no longer a "fork" because it will rename the package name, but that will hopefully make Satis and all our projects which want to include this library work correctly.